### PR TITLE
Fix build script and change to use fs.chmod

### DIFF
--- a/agent/packages/numasec/script/build.ts
+++ b/agent/packages/numasec/script/build.ts
@@ -5,6 +5,7 @@ import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
 import solidPlugin from "@opentui/solid/bun-plugin"
+import { chmod } from "fs/promises"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -253,7 +254,7 @@ for (const item of targets) {
   }
 
   await $`rm -rf ./dist/${name}/bin/tui`
-  await $`chmod +x ./dist/${name}/bin/numasec`
+  if (!["win32", "windows"].includes(item.os.toLocaleLowerCase())) await chmod(`./dist/${name}/bin/numasec`, 0o755)
 
   // Postinstall to fix permissions (npm may strip execute bit)
   await Bun.file(`dist/${name}/postinstall.js`).write(


### PR DESCRIPTION
Changes
- Replaced shell command: $ chmod +x ./dist/${name}/bin/numasec
- With Node.js native API: fs.chmod(path, 0o755) for more reliable permission setting
- Updated OS condition to ensure chmod only runs for non-Windows targets: if (!["win32", "windows"].includes(item.os))

Benefits
- Improves cross-platform compatibility (especially in CI/CD)
- Removes dependency on shell environment
- Ensures consistent and deterministic file permissions (755)
- Prevents potential failures on Windows

Notes
- Windows does not require executable permissions, so chmod is safely skipped.